### PR TITLE
Add support to set policy on the SimpliVity datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /backups/delete <POST>
     - endpoint support for /backups/{bkpId} <DELETE>
     - endpoint support for /backups/{bkpId}/restore <POST>
+    - endpoint support for /cluster_groups <GET>
     - endpoint support for /datastore <POST>
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /datastore/{datastoreId}/resize <POST>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
     - address unittest.assertequals deprecation warning within unit test cases
+    - default accept header to application/json
     - leverage pprint in the ./examples/datastores.py to improve the overall readability of the output
     - policy test cases to improve the existing code coverage metrics
     - reformat existing docstrings to conform to Sphinx documentation requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - static ip address within a unit test to the loopback ip address
 
 ### Fixed
+    - exception handling within the ovc client module
     - required __init__.py files to support unit test discovery
     - resolve failing unit test cases
     - url encode query string to support values that contain spaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - policy test cases to improve the existing code coverage metrics
     - reformat existing docstrings to conform to Sphinx documentation requirements
     - rename the unit test filenames to reflect which objects were being targeted
+    - static ip address within a unit test to the loopback ip address
 
 ### Fixed
     - required __init__.py files to support unit test discovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /datastore/{datastoreId}/resize <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
-    - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies <POST>
+    - endpoint support for /policies/{policyId} <DELETE>
+    - missing ovc client host unit tests to improve code coverage
     - pull request template to facilitate pull requests
     - query string support for post operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /datastore <POST>
     - endpoint support for /datastore/{datastoreId} <DELETE>
     - endpoint support for /datastore/{datastoreId}/resize <POST>
+    - endpoint support for /datastore/{datastoreId}/set_policy <POST>
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /policies <POST>
     - endpoint support for /policies/{policyId} <DELETE>

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -18,6 +18,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/datastores	</sub>                                                                |POST       |
 |<sub>/datastores/{datastoreId}  </sub>                                                   |DELETE    |
 |<sub>/datastores/{datastoreId}/resize  </sub>                                            |POST      |
+|<sub>/datastores/{datastoreId}/set_policy  </sub>                                        |POST      |
 |     **Hosts**
 |<sub>/hosts	</sub>                                                                    |GET       |
 |<sub>/hosts/{hostId}/remove_from_federation  </sub>						|POST      |

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -11,6 +11,8 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/backups/delete  </sub>                                                             |POST      |
 |<sub>/backups/{bkpId}  </sub>                                                            |DELETE    |
 |<sub>/backups/{bkpId}/restore  </sub>                                                    |POST      |
+|     **Cluster Groups**
+|<sub>/cluster_groups  </sub>                                                             |GET       |
 |     **Datastores**
 |<sub>/datastores	</sub>                                                                |GET       |
 |<sub>/datastores	</sub>                                                                |POST       |

--- a/examples/cluster_groups.py
+++ b/examples/cluster_groups.py
@@ -1,0 +1,77 @@
+###
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
+import pprint
+
+from simplivity.ovc_client import OVC
+from simplivity.exceptions import HPESimpliVityException
+
+pp = pprint.PrettyPrinter(indent=4)
+
+config = {
+    "ip": "<ovc_ip>",
+    "credentials": {
+        "username": "<username>",
+        "password": "<password>"
+    }
+}
+
+ovc = OVC(config)
+cluster_groups = ovc.cluster_groups
+
+print("\n\nget_all with default params")
+all_cluster_groups = cluster_groups.get_all()
+for cluster_group in all_cluster_groups:
+    print(f"{cluster_group}")
+    print(f"{pp.pformat(cluster_group.data)} \n")
+count = len(all_cluster_groups)
+print(f"Total number of cluster groups : {count}")
+
+cluster_group_object = all_cluster_groups[0]
+
+cluster_group_name = cluster_group_object.data["name"]
+print("\n\nget_all with name filter")
+all_cluster_groups = cluster_groups.get_all(filters={'name': cluster_group_name})
+for cluster_group in all_cluster_groups:
+    print(f"{cluster_group}")
+    print(f"{pp.pformat(cluster_group.data)} \n")
+count = len(all_cluster_groups)
+print(f"Total number of cluster groups : {count}")
+
+print("\n\nget_all with pagination")
+pagination = cluster_groups.get_all(limit=10, pagination=True, page_size=2)
+end = False
+while not end:
+    data = pagination.data
+    print(f"page size : {len(data['resources'])}")
+    print(f"{pp.pformat(data)} \n")
+
+    try:
+        pagination.next_page()
+    except HPESimpliVityException:
+        end = True
+
+cluster_group_id = cluster_group_object.data["id"]
+print("\n\nget_by_id")
+cluster_group = cluster_groups.get_by_id(cluster_group_id)
+print(f"{cluster_group}")
+print(f"{pp.pformat(cluster_group.data)} \n")
+
+cluster_group_name = cluster_group_object.data["name"]
+print("\n\nget_by_name")
+cluster_group = cluster_groups.get_by_name(cluster_group_name)
+print(f"{cluster_group}")
+print(f"{pp.pformat(cluster_group.data)} \n")

--- a/examples/datastores.py
+++ b/examples/datastores.py
@@ -95,13 +95,27 @@ datastore_object = datastore_object.resize(datastore_size)
 print(f"{datastore_object}")
 print(f"{pp.pformat(datastore_object.data)} \n")
 
+# Set policy to the datastore
+print("\n\nset policy on the datastore")
+policy_object = policies.create("fixed_retention_policy")
+print(f"{policy_object}")
+print(f"{pp.pformat(policy_object.data)} \n")
+
+datastore_object.set_policy(policy_object)
+print(f"{datastore_object}")
+print(f"{pp.pformat(datastore_object.data)} \n")
+
 print("\n\ndatastore delete")
 all_datastores = datastores.get_all()
 count = len(all_datastores)
 print(f"Total number of datastores before delete: {count} \n")
 datastore_object.delete()
+
+# delete the new policy created
+policy_object.delete()
 print(f"{datastore_object}")
 print(f"{pp.pformat(datastore_object.data)} \n")
+
 all_datastores = datastores.get_all()
 count = len(all_datastores)
 print(f"Total number of datastores after delete: {count}")

--- a/simplivity/connection.py
+++ b/simplivity/connection.py
@@ -43,7 +43,7 @@ class Connection(object):
         self._password = None
         self._access_token = None
 
-        self._headers = {'Accept': 'application/vnd.simplivity.v1+json'}
+        self._headers = {'Accept': 'application/json'}
         self._base_url = "https://{}/api".format(ovc_ip)
         self.__connection = None
 

--- a/simplivity/ovc_client.py
+++ b/simplivity/ovc_client.py
@@ -42,7 +42,7 @@ class OVC(object):
             password = config["credentials"].get("password")
             self.__connection.login(username, password)
         else:
-            exceptions.HPESimpliVityException("Credentials not provided")
+            raise exceptions.HPESimpliVityException("Credentials not provided")
 
         self.__virtual_machines = None
         self.__policies = None
@@ -83,7 +83,7 @@ class OVC(object):
         timeout = os.environ.get('SIMPLIVITYSDK_CONNECTION_TIMEOUT')
 
         if not ip or not username or not password:
-            raise exceptions.SimplivityExceptions("Make sure you have set mandatory env variables \
+            raise exceptions.HPESimpliVityException("Make sure you have set mandatory env variables \
             (SIMPLIVITYSDK_OVC_IP, SIMPLIVITYSDK_USERNAME, SIMPLIVITYSDK_PASSWORD)")
 
         config = dict(ip=ip,

--- a/simplivity/ovc_client.py
+++ b/simplivity/ovc_client.py
@@ -20,15 +20,15 @@ This module implements a common client for HPE SimpliVity resources.
 import json
 import os
 
-from simplivity.connection import Connection
 from simplivity import exceptions
-
-from simplivity.resources.virtual_machines import VirtualMachines
-from simplivity.resources.policies import Policies
-from simplivity.resources.datastores import Datastores
-from simplivity.resources.omnistack_clusters import OmnistackClusters
+from simplivity.connection import Connection
 from simplivity.resources.backups import Backups
+from simplivity.resources.cluster_groups import ClusterGroups
+from simplivity.resources.datastores import Datastores
 from simplivity.resources.hosts import Hosts
+from simplivity.resources.omnistack_clusters import OmnistackClusters
+from simplivity.resources.policies import Policies
+from simplivity.resources.virtual_machines import VirtualMachines
 
 
 class OVC(object):
@@ -50,6 +50,7 @@ class OVC(object):
         self.__omnistack_clusters = None
         self.__backups = None
         self.__hosts = None
+        self.__cluster_groups = None
 
     @classmethod
     def from_json_file(cls, file_name):
@@ -173,3 +174,15 @@ class OVC(object):
         if not self.__hosts:
             self.__hosts = Hosts(self.__connection)
         return self.__hosts
+
+    @property
+    def cluster_groups(self):
+        """
+        Gets the cluster groups client.
+
+        Returns:
+            ClusterGroups object
+        """
+        if not self.__cluster_groups:
+            self.__cluster_groups = ClusterGroups(self.__connection)
+        return self.__cluster_groups

--- a/simplivity/resources/cluster_groups.py
+++ b/simplivity/resources/cluster_groups.py
@@ -1,0 +1,84 @@
+###
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
+from simplivity.resources.resource import ResourceBase
+
+URL = '/cluster_groups'
+DATA_FIELD = 'cluster_groups'
+
+
+class ClusterGroups(ResourceBase):
+    """Implements features available for cluster group resources."""
+
+    def __init__(self, connection):
+        super(ClusterGroups, self).__init__(connection)
+
+    def get_all(self, pagination=False, page_size=0, limit=500, offset=0,
+                sort=None, order='descending', filters=None, fields=None,
+                case_sensitive=True, show_optional_fields=False):
+        """Gets all cluster groups.
+
+        Args:
+            pagination: True if need pagination
+            page_size: Size of the page (Required when pagination is on)
+            limit: A positive integer that represents the maximum number of results to return
+            offset: A positive integer that directs the service to start returning
+              the <offset value> instance, up to the limit.
+            sort: The name of the field where the sort occurs.
+            order: The sort order preference. Valid values: ascending or descending.
+            filters: Dictionary with filter values. Example: {'name': 'name'}
+              id: The unique identifier (UID) of the omnistack_clusters to return
+                Accepts: Single value, comma-separated list
+              name: The name of the omnistack_clusters to return
+                Accepts: Single value, comma-separated list, pattern using one or more
+                asterisk characters as a wildcard
+
+        Returns:
+          list: list of OmnistackCluster
+        """
+        return self._client.get_all(URL,
+                                    members_field=DATA_FIELD,
+                                    pagination=pagination,
+                                    page_size=page_size,
+                                    limit=limit,
+                                    offset=offset,
+                                    sort=sort,
+                                    order=order,
+                                    filters=filters,
+                                    fields=fields,
+                                    case_sensitive=case_sensitive,
+                                    show_optional_fields=show_optional_fields)
+
+    def get_by_data(self, data):
+        """Gets ClusterGroup object from data.
+
+        Args:
+            data: ClusterGroup data
+
+        Returns:
+            object: ClusterGroup object.
+        """
+
+        return ClusterGroup(self._connection, self._client, data)
+
+
+class ClusterGroup(object):
+    """Implements features available for single cluster group resource."""
+
+    def __init__(self, connection, resource_client, data):
+        self.data = data
+        self._connection = connection
+        self._client = resource_client

--- a/simplivity/resources/datastores.py
+++ b/simplivity/resources/datastores.py
@@ -151,6 +151,11 @@ class Datastore(object):
         self._connection = connection
         self._client = resource_client
 
+    def __refresh(self):
+        """Updates the datastore data."""
+        resource_uri = "{}/{}".format(URL, self.data["id"])
+        self.data = self._client.do_get(resource_uri)['datastore']
+
     def delete(self, timeout=-1):
         """Deletes a datastore."""
         resource_uri = "{}/{}".format(URL, self.data["id"])
@@ -174,5 +179,27 @@ class Datastore(object):
         datastore = Datastores(self._connection)
         datastore_obj = datastore.get_by_id(out[0]["object_id"])
         self.data = datastore_obj.data
+
+        return self
+
+    def set_policy(self, policy, timeout=-1):
+        """Sets the backup policy for a datastore.
+
+        Args:
+            policy: Policy object/name
+            timeout: Time out for the request in seconds.
+
+        Returns:
+            object: Datastore object.
+
+        """
+        resource_uri = "{}/{}/set_policy".format(URL, self.data["id"])
+        if not isinstance(policy, policies.Policy):
+            # if passed name of the policy
+            policy = policies.Policies(self._connection).get_by_name(policy)
+
+        data = {"policy_id": policy.data['id']}
+        self._client.do_post(resource_uri, data, timeout, None)
+        self.__refresh()
 
         return self

--- a/tests/unit/resources/test_cluster_groups.py
+++ b/tests/unit/resources/test_cluster_groups.py
@@ -1,0 +1,95 @@
+###
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
+import unittest
+from unittest import mock
+
+from simplivity.connection import Connection
+from simplivity import exceptions
+from simplivity.resources import cluster_groups
+
+
+class ClusterGroupsTest(unittest.TestCase):
+    def setUp(self):
+        self.connection = Connection('127.0.0.1')
+        self.connection._access_token = "123456789"
+        self.cluster_groups = cluster_groups.ClusterGroups(self.connection)
+
+    @mock.patch.object(Connection, "get")
+    def test_get_all_returns_resource_obj(self, mock_get):
+        url = "{}?case=sensitive&limit=500&offset=0&order=descending&sort=name".format(cluster_groups.URL)
+        resource_data = [{'clusters': ['12345'], 'name': 'clustergroup01', 'id': '12345'}]
+        mock_get.return_value = {cluster_groups.DATA_FIELD: resource_data}
+
+        objs = self.cluster_groups.get_all()
+        self.assertIsInstance(objs[0], cluster_groups.ClusterGroup)
+        self.assertEqual(objs[0].data, resource_data[0])
+        mock_get.assert_called_once_with(url)
+
+    @mock.patch.object(Connection, "get")
+    def test_get_by_name_found(self, mock_get):
+        name = "testname"
+        url = "{}?case=sensitive&limit=500&name={}&offset=0&order=descending&sort=name".format(cluster_groups.URL, name)
+        resource_data = [{'id': '12345', 'name': name}]
+        mock_get.return_value = {cluster_groups.DATA_FIELD: resource_data}
+
+        obj = self.cluster_groups.get_by_name(name)
+        self.assertIsInstance(obj, cluster_groups.ClusterGroup)
+        mock_get.assert_called_once_with(url)
+
+    @mock.patch.object(Connection, "get")
+    def test_get_by_name_not_found(self, mock_get):
+        name = "testname"
+        resource_data = []
+        mock_get.return_value = {cluster_groups.DATA_FIELD: resource_data}
+
+        with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
+            self.cluster_groups.get_by_name(name)
+
+        self.assertEqual(error.exception.msg, "Resource not found with the name {}".format(name))
+
+    @mock.patch.object(Connection, "get")
+    def test_get_by_id_found(self, mock_get):
+        resource_id = "12345"
+        url = "{}?case=sensitive&id={}&limit=500&offset=0&order=descending&sort=name".format(cluster_groups.URL, resource_id)
+        resource_data = [{'id': resource_id}]
+        mock_get.return_value = {cluster_groups.DATA_FIELD: resource_data}
+
+        obj = self.cluster_groups.get_by_id(resource_id)
+        self.assertIsInstance(obj, cluster_groups.ClusterGroup)
+        mock_get.assert_called_once_with(url)
+
+    @mock.patch.object(Connection, "get")
+    def test_get_by_id_not_found(self, mock_get):
+        resource_id = "12345"
+        resource_data = []
+        mock_get.return_value = {cluster_groups.DATA_FIELD: resource_data}
+
+        with self.assertRaises(exceptions.HPESimpliVityResourceNotFound) as error:
+            self.cluster_groups.get_by_id(resource_id)
+
+        self.assertEqual(error.exception.msg, "Resource not found with the id {}".format(resource_id))
+
+    def test_get_by_data(self):
+        resource_data = {'id': '12345'}
+
+        obj = self.cluster_groups.get_by_data(resource_data)
+        self.assertIsInstance(obj, cluster_groups.ClusterGroup)
+        self.assertEqual(obj.data, resource_data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/resources/test_datastores.py
+++ b/tests/unit/resources/test_datastores.py
@@ -173,6 +173,41 @@ class DatastoresTest(unittest.TestCase):
         self.assertEqual(datastore.data, resource_data[0])
         mock_post.assert_called_once_with('/datastores/12345/resize', {'size': 2048}, custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_policy_with_policy_name(self, mock_get, mock_post):
+        resource_data = {'name': 'ds1', 'id': '12345', 'policy_id': '4567'}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        policy_name = 'policy1'
+        mock_get.side_effect = [{'policies': [{'name': policy_name, 'id': '4567'}]},
+                                {'datastore': resource_data}]
+
+        datastore_data = {'name': 'ds1', 'id': '12345', 'policy_id': '7890'}
+        datastore = self.datastores.get_by_data(datastore_data)
+        datastore.set_policy(policy_name)
+        self.assertIsInstance(datastore, datastores.Datastore)
+        self.assertEqual(datastore.data, resource_data)
+
+        mock_post.assert_called_once_with('/datastores/12345/set_policy', {'policy_id': '4567'},
+                                          custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_set_policy_with_policy_obj(self, mock_get, mock_post):
+        resource_data = {'name': 'ds1', 'id': '12345', 'policy_id': '7890'}
+        mock_post.return_value = None, [{'object_id': '12345'}]
+        mock_get.return_value = {'datastore': resource_data}
+        policy_obj = self.policies.get_by_data({'id': '4567', 'name': 'policy1'})
+
+        datastore_data = {'name': 'ds1', 'id': '12345', 'policy_id': '7890'}
+        datastore = self.datastores.get_by_data(datastore_data)
+        datastore.set_policy(policy_obj)
+        self.assertIsInstance(datastore, datastores.Datastore)
+        self.assertEqual(datastore.data, resource_data)
+
+        mock_post.assert_called_once_with('/datastores/12345/set_policy', {'policy_id': '4567'},
+                                          custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -35,7 +35,7 @@ class ConnectionTest(unittest.TestCase):
         }
         self.default_headers = {'Content-type': 'application/vnd.simplivity.v1.8+json',
                                 'Authorization': 'Bearer 123456789',
-                                'Accept': 'application/vnd.simplivity.v1+json'}
+                                'Accept': 'application/json'}
 
         self.updated_headers = self.default_headers.copy()
         self.updated_headers.update(self.new_content_type)

--- a/tests/unit/test_ovc_client.py
+++ b/tests/unit/test_ovc_client.py
@@ -30,7 +30,7 @@ from simplivity.resources.policies import Policies
 from simplivity.resources.virtual_machines import VirtualMachines
 
 OS_ENVIRON_CONFIG = {
-    'SIMPLIVITYSDK_OVC_IP': '10.30.4.245',
+    'SIMPLIVITYSDK_OVC_IP': '127.0.0.1',
     'SIMPLIVITYSDK_USERNAME': 'simplicity',
     'SIMPLIVITYSDK_PASSWORD': 'root',
     'SIMPLIVITYSDK_SSL_CERTIFICATE': 'certificate',
@@ -48,7 +48,7 @@ class OVCTest(unittest.TestCase):
     def setUp(self, mock_login):
         super(OVCTest, self).setUp()
 
-        config = {"ip": "10.30.4.245",
+        config = {"ip": "127.0.0.1",
                   "credentials": {
                       "username": "simplivity",
                       "password": "root"}}
@@ -62,7 +62,7 @@ class OVCTest(unittest.TestCase):
     @mock.patch(mock_builtin('open'))
     def test_from_json_file(self, mock_open, mock_login):
         json_config_content = u"""{
-          "ip": "10.30.4.245",
+          "ip": "127.0.0.1",
           "credentials": {
             "username": "simplicity",
             "password": "root"
@@ -72,7 +72,7 @@ class OVCTest(unittest.TestCase):
         ovc_client = OVC.from_json_file("config.json")
 
         self.assertIsInstance(ovc_client, OVC)
-        self.assertEqual("10.30.4.245", ovc_client.connection._ovc_ip)
+        self.assertEqual("127.0.0.1", ovc_client.connection._ovc_ip)
 
     @mock.patch.object(Connection, 'login')
     @mock.patch.dict('os.environ', OS_ENVIRON_CONFIG)
@@ -86,7 +86,7 @@ class OVCTest(unittest.TestCase):
         mock_cls.return_value = None
         OVC.from_environment_variables()
         mock_cls.assert_called_once_with({'timeout': '-1',
-                                          'ip': '10.30.4.245',
+                                          'ip': '127.0.0.1',
                                           'ssl_certificate': 'certificate',
                                           'credentials': {'username': 'simplicity',
                                                           'password': 'root'}})

--- a/tests/unit/test_ovc_client.py
+++ b/tests/unit/test_ovc_client.py
@@ -19,15 +19,14 @@ import sys
 import unittest
 from unittest import mock
 
-
 from simplivity.connection import Connection
 from simplivity.ovc_client import OVC
-from simplivity.resources.virtual_machines import VirtualMachines
-from simplivity.resources.policies import Policies
+from simplivity.resources.backups import Backups
+from simplivity.resources.cluster_groups import ClusterGroups
 from simplivity.resources.datastores import Datastores
 from simplivity.resources.omnistack_clusters import OmnistackClusters
-from simplivity.resources.backups import Backups
-
+from simplivity.resources.policies import Policies
+from simplivity.resources.virtual_machines import VirtualMachines
 
 OS_ENVIRON_CONFIG = {
     'SIMPLIVITYSDK_OVC_IP': '10.30.4.245',
@@ -140,6 +139,16 @@ class OVCTest(unittest.TestCase):
     def test_lazy_loading_backups(self):
         backups = self._ovc.backups
         self.assertEqual(backups, self._ovc.backups)
+
+    def test_cluster_groups_has_right_type(self):
+        self.assertIsInstance(self._ovc.cluster_groups, ClusterGroups)
+
+    def test_cluster_groups_has_value(self):
+        self.assertIsNotNone(self._ovc.cluster_groups)
+
+    def test_lazy_loading_cluster_groups(self):
+        cluster_groups = self._ovc.cluster_groups
+        self.assertEqual(cluster_groups, self._ovc.cluster_groups)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_ovc_client.py
+++ b/tests/unit/test_ovc_client.py
@@ -24,6 +24,7 @@ from simplivity.ovc_client import OVC
 from simplivity.resources.backups import Backups
 from simplivity.resources.cluster_groups import ClusterGroups
 from simplivity.resources.datastores import Datastores
+from simplivity.resources.hosts import Hosts
 from simplivity.resources.omnistack_clusters import OmnistackClusters
 from simplivity.resources.policies import Policies
 from simplivity.resources.virtual_machines import VirtualMachines
@@ -139,6 +140,16 @@ class OVCTest(unittest.TestCase):
     def test_lazy_loading_backups(self):
         backups = self._ovc.backups
         self.assertEqual(backups, self._ovc.backups)
+
+    def test_hosts_has_right_type(self):
+        self.assertIsInstance(self._ovc.hosts, Hosts)
+
+    def test_hosts_has_value(self):
+        self.assertIsNotNone(self._ovc.hosts)
+
+    def test_lazy_loading_hosts(self):
+        hosts = self._ovc.hosts
+        self.assertEqual(hosts, self._ovc.hosts)
 
     def test_cluster_groups_has_right_type(self):
         self.assertIsInstance(self._ovc.cluster_groups, ClusterGroups)


### PR DESCRIPTION
### Description
Add support to set policy on the SimpliVity datastore

### Issues Resolved
NA

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
