### PR TITLE
Add support for creating rules in the Simplivity policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - endpoint support for /hosts/{hostId}/remove_from_federation <POST>    
     - endpoint support for /policies/{policyId} <DELETE>
     - endpoint support for /policies <POST>
+    - endpoint support for /policies/{policyId}/rules <POST>
     - pull request template to facilitate pull requests
     - query string support for post operations
 

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -25,6 +25,7 @@ Refer SimpliVity REST API doc for the resource endpoints documentation [HPE Simp
 |<sub>/policies	</sub>                                                                    |GET       |
 |<sub>/policies</sub>                                                                     |POST      |
 |<sub>/policies/{policyId} </sub>                                                         |DELETE    |
+|<sub>/policies/{policyId}/rules </sub>                                                   |POST      |
 |     **Virtual Machines**
 |<sub>/virtual_machines	</sub>                                                            |GET       |
 |<sub>/virtual_machines/set_policy	</sub>                                                |POST      |

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -83,7 +83,31 @@ print(f"{pp.pformat(vms)} \n")
 print("\n\ncreate policy")
 policy_name = "fixed_frequency_retention_policy"
 policy = policies.create(policy_name)
-print(policy, policy.data)
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
+multiple_rules = [
+    {
+        "start_time": "14:30",
+        "end_time": "15:30",
+        "application_consistent": False,
+        "frequency": 3,
+        "retention": 5
+    },
+    {
+        "frequency": 5,
+        "retention": 6
+    }
+]
+
+print("\n\nadd rules to policy")
+policy.create_rules(multiple_rules)
+print(f"{policy}")
+print(f"{pp.pformat(policy.data)} \n")
+single_rule = {
+    "frequency": 10,
+    "retention": 12
+}
+policy.create_rules(single_rule)
 print(f"{policy}")
 print(f"{pp.pformat(policy.data)} \n")
 

--- a/simplivity/resources/policies.py
+++ b/simplivity/resources/policies.py
@@ -98,6 +98,11 @@ class Policy(object):
         self._connection = connection
         self._client = resource_client
 
+    def __refresh(self):
+        """Updates the policy data."""
+        resource_uri = "{}/{}".format(URL, self.data["id"])
+        self.data = self._client.do_get(resource_uri)['policy']
+
     def get_vms(self):
         """Retrieves the virtual machines using this policy.
 
@@ -120,3 +125,50 @@ class Policy(object):
         resource_uri = "{}/{}".format(URL, self.data["id"])
         self._client.do_delete(resource_uri, timeout, None)
         self.data = None
+
+    def create_rules(self, rules, replace_all_rules=False, timeout=-1):
+        """Creates one or more new rules or replaces existing rules with new rules for a policy
+
+        Args:
+            rules: Array of rules.(below are the parameter that can be passed in the array)
+                [Mandatory Parameters]
+                frequency: The number of minutes between backups
+                retention: The number of minutes to keep backups
+                [Optional Parameters]
+                application_consistent: Set false for crash-consistent backups
+                                        Set true for application-consistent backups (for example, VSS or snapshot backups)
+                                        Default: false
+                consistency_type: Set to DEFAULT for a snapshot backup
+                                  Set to VSS for a Microsoft Volume Shadow Copy Service backup
+                                  Set to NONE for crash-consistent backups
+                                  Default: NONE
+                destination_id: The unique identifier (UID) of the omnistack_cluster to store the backup
+                                Default: local omnistack_cluster
+                days: The days of the week (for example, Mon,Fri), or month (for example, 1,15) to take backups or
+                      "last" to specify the last day of each month
+                      Default: All (that is, every day)
+                start_time: The time to start the backups, for example, 14:30
+                            This time is local to the time zone of the Hypervisor Management System (HMS)
+                            Default: 00:00
+                end_time: The time to stop backing up, for example, 14:30
+                          This time is local to the time zone of the Hypervisor Management System (HMS)
+                          Default: 00:00
+                external_store_name: The name of the external_store
+
+            replace_all_rules: If set to True, replaces the existing rules with new rules
+                               If set to False, adds the new rules to existing set of rules
+            timeout: Time out for the request in seconds.
+
+
+        Returns:
+            self: Returns the policy object.
+        """
+        resource_uri = "{}/{}/rules".format(URL, self.data["id"])
+        if isinstance(rules, dict):
+            rules = [rules]
+
+        flags = {'replace_all_rules': replace_all_rules}
+        self._client.do_post(resource_uri, rules, timeout, None, flags)[0]
+        self.__refresh()
+
+        return self

--- a/tests/unit/resources/test_policies.py
+++ b/tests/unit/resources/test_policies.py
@@ -154,6 +154,49 @@ class PoliciesTest(unittest.TestCase):
         self.assertEqual(policy.data, resource_data[0])
         mock_post.assert_called_once_with('/policies', data, custom_headers=None)
 
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_create_multiple_rules(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': 'policy12345'}]
+        resources_data = {"rules": [{"frequency": 5, "id": "12345", "retention": 1},
+                                    {"frequency": 10, "id": "67890", "retention": 2}], "name": "name",
+                          "id": "policy12345"}
+
+        mock_get.return_value = {'policy': resources_data}
+        policy_obj = self.policies.get_by_data({'id': 'policy12345', 'name': 'name'})
+        rules = [
+            {
+                "frequency": 1,
+                "retention": 5
+            },
+            {
+                "frequency": 10,
+                "retention": 2
+            }
+        ]
+        policy_obj.create_rules(rules)
+        self.assertEqual(policy_obj.data, resources_data)
+        mock_post.assert_called_once_with('/policies/policy12345/rules?replace_all_rules=False', rules,
+                                          custom_headers=None)
+
+    @mock.patch.object(Connection, "post")
+    @mock.patch.object(Connection, "get")
+    def test_create_single_rules(self, mock_get, mock_post):
+        mock_post.return_value = None, [{'object_id': 'policy12345'}]
+        resources_data = {"rules": [{"frequency": 5, "id": "12345", "retention": 1}], "name": "name",
+                          "id": "policy12345"}
+
+        mock_get.return_value = {'policy': resources_data}
+        policy_obj = self.policies.get_by_data({'id': 'policy12345', 'name': 'name'})
+        rules = {
+            "frequency": 1,
+            "retention": 5
+        }
+        policy_obj.create_rules(rules)
+        self.assertEqual(policy_obj.data, resources_data)
+        mock_post.assert_called_once_with('/policies/policy12345/rules?replace_all_rules=False', [rules],
+                                          custom_headers=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description
Add support for creating rules in the Simplivity policy

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
